### PR TITLE
Adding Stem Stage

### DIFF
--- a/coatnet/models/blocks.py
+++ b/coatnet/models/blocks.py
@@ -1,9 +1,16 @@
 import tensorflow as tf
-import tensorflow_addons as tfa
 from tensorflow.keras import layers
 
 
-def conv_3x3(input_layer, num_filters=64, downsample=False):
+def conv_3x3(input_layer, num_filters: int = 64, downsample: bool = False):
+    """
+    3x3 Convolutional Stem Stage.
+
+    Args:
+        input_layer: input tensor
+        num_filters: number of filters in the convolutional layer
+        downsample: whether to downsample the input layer or not
+    """
     stride = 1 if downsample == False else 2
     conv_1 = layers.Conv2D(
         filters=num_filters,
@@ -13,5 +20,5 @@ def conv_3x3(input_layer, num_filters=64, downsample=False):
         use_bias=False,
     )(input_layer)
     bn_1 = layers.BatchNormalization()(conv_1)
-    act_1 = tfa.layers.GELU()(bn_1)
+    act_1 = tf.nn.gelu(bn_1)
     return act_1

--- a/coatnet/models/blocks.py
+++ b/coatnet/models/blocks.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+import tensorflow_addons as tfa
+from tensorflow.keras import layers
+
+
+def conv_3x3(input_layer, num_filters=64, downsample=False):
+    stride = 1 if downsample == False else 2
+    conv_1 = layers.Conv2D(
+        filters=num_filters,
+        kernel_size=(3, 3),
+        strides=stride,
+        padding="same",
+        use_bias=False,
+    )(input_layer)
+    bn_1 = layers.BatchNormalization()(conv_1)
+    act_1 = tfa.layers.GELU()(bn_1)
+    return act_1

--- a/coatnet/models/coatnet.py
+++ b/coatnet/models/coatnet.py
@@ -5,26 +5,21 @@ from tensorflow import keras
 from coatnet.models.blocks import conv_3x3
 
 
-class CoAtNet(keras.models.Model):
-    def __init__(self, model_name: str, image_shape: tuple, num_classes: int, **kwargs):
-        super(CoAtNet, self).__init__(**kwargs)
-        self.model_name = model_name
-        self.image_shape = image_shape
-        self.num_classes = num_classes
+def get_training_model(
+    model_name: str, image_shape: tuple, num_classes: int
+) -> keras.Model:
+    """
+    Implements CoAtNet family of models given a configuration.
+    References:
+        (1) https://arxiv.org/pdf/2106.04803.pdf
+    """
+    configs = get_model_config(model_name)
 
-    def get_training_model(self):
-        """
-        Implements CoAtNet family of models given a configuration.
-        References:
-            (1) https://arxiv.org/pdf/2106.04803.pdf
-        """
-        configs = get_model_config(self.model_name)
-
-        input_layer = keras.Input(shape=self.image_shape)  # Input Layer
-        conv_1 = conv_3x3(
-            input_layer=input_layer,
-            num_filters=configs.out_channels[0],
-            downsample=True,
-        )  # Conv Stem Block
-        conv_2 = conv_3x3(input_layer=conv_1, num_filters=configs.out_channels[0])
-        print(conv_2.shape)
+    input_layer = keras.Input(shape=image_shape)  # Input Layer
+    conv_1 = conv_3x3(
+        input_layer=input_layer,
+        num_filters=configs.out_channels[0],
+        downsample=True,
+    )  # Conv Stem Block
+    conv_2 = conv_3x3(input_layer=conv_1, num_filters=configs.out_channels[0])
+    print(conv_2.shape)

--- a/coatnet/models/coatnet.py
+++ b/coatnet/models/coatnet.py
@@ -1,0 +1,30 @@
+import tensorflow as tf
+from configs.model_configs import get_model_config
+from tensorflow import keras
+
+from coatnet.models.blocks import conv_3x3
+
+
+class CoAtNet(keras.models.Model):
+    def __init__(self, model_name: str, image_shape: tuple, num_classes: int, **kwargs):
+        super(CoAtNet, self).__init__(**kwargs)
+        self.model_name = model_name
+        self.image_shape = image_shape
+        self.num_classes = num_classes
+
+    def get_training_model(self):
+        """
+        Implements ConvNeXt family of models given a configuration.
+        References:
+            (1) https://arxiv.org/pdf/2106.04803.pdf
+        """
+        configs = get_model_config(self.model_name)
+
+        input_layer = keras.Input(shape=self.image_shape)  # Input Layer
+        conv_1 = conv_3x3(
+            input_layer=input_layer,
+            num_filters=configs.out_channels[0],
+            downsample=True,
+        )  # Conv Stem Block
+        conv_2 = conv_3x3(input_layer=conv_1, num_filters=configs.out_channels[0])
+        print(conv_2.shape)

--- a/coatnet/models/coatnet.py
+++ b/coatnet/models/coatnet.py
@@ -14,7 +14,7 @@ class CoAtNet(keras.models.Model):
 
     def get_training_model(self):
         """
-        Implements ConvNeXt family of models given a configuration.
+        Implements CoAtNet family of models given a configuration.
         References:
             (1) https://arxiv.org/pdf/2106.04803.pdf
         """

--- a/configs/classifier.py
+++ b/configs/classifier.py
@@ -1,0 +1,17 @@
+import ml_collections
+
+
+def get_config() -> ml_collections.ConfigDict:
+    config = ml_collections.ConfigDict()
+    config.model_name = "coatnet_0"
+    config.image_height = 224  # Image height
+    config.image_width = 224  # Image width
+    config.image_channels = 3  # Number of channels
+
+    config.expansion_rate = 4  # Expansion rate of inverted bottleneck
+    config.se_ratio = 0.25  # Squeeze and Excitation ratio
+    config.batch_size = 128  # Batch size for training.
+    config.epochs = 100  # Number of epochs to train for.
+    config.num_classes = 1000  # Number of classes in the dataset.
+
+    return config

--- a/configs/model_configs.py
+++ b/configs/model_configs.py
@@ -1,0 +1,91 @@
+"""
+Configuratiionns for different CoAtNet variants. 
+Referred from: https://arxiv.org/abs/2106.04803
+"""
+
+
+import ml_collections
+
+
+def coatnet_0_config() -> ml_collections.ConfigDict:
+    configs = ml_collections.ConfigDict()
+    configs.num_blocks = [2, 2, 3, 5, 2]  # L
+    configs.out_channels = [64, 96, 192, 384, 768]  # D
+    return configs
+
+
+def coatnet_1_config() -> ml_collections.ConfigDict:
+    configs = ml_collections.ConfigDict()
+    configs.num_blocks = [2, 2, 6, 14, 2]  # L
+    configs.out_channels = [64, 96, 192, 384, 768]  # D
+    return configs
+
+
+def coatnet_2_config() -> ml_collections.ConfigDict:
+    configs = ml_collections.ConfigDict()
+    configs.num_blocks = [2, 2, 6, 14, 2]  # L
+    configs.out_channels = [128, 128, 256, 512, 1024]  # D
+    return configs
+
+
+def coatnet_3_config() -> ml_collections.ConfigDict:
+    configs = ml_collections.ConfigDict()
+    configs.num_blocks = [2, 2, 6, 14, 2]  # L
+    configs.out_channels = [192, 192, 384, 768, 1536]  # D
+    return configs
+
+
+def coatnet_4_config() -> ml_collections.ConfigDict:
+    configs = ml_collections.ConfigDict()
+    configs.num_blocks = [2, 2, 12, 28, 2]  # L
+    configs.out_channels = [192, 192, 384, 768, 1536]  # D
+    return configs
+
+
+def coatnet_5_config() -> ml_collections.ConfigDict:
+    configs = ml_collections.ConfigDict()
+    configs.num_blocks = [2, 2, 12, 28, 2]  # L
+    configs.out_channels = [192, 256, 512, 1280, 2048]  # D
+    return configs
+
+
+def coatnet_6_config() -> ml_collections.ConfigDict:
+    configs = ml_collections.ConfigDict()
+    configs.num_blocks = [2, 2, 6, 8, 42, 2]  # L
+    configs.out_channels = [192, 192, 384, 768, 1536, 2048]  # D
+    return configs
+
+
+def coatnet_7_config() -> ml_collections.ConfigDict:
+    configs = ml_collections.ConfigDict()
+    configs.num_blocks = [2, 2, 6, 8, 42, 2]  # L
+    configs.out_channels = [192, 256, 512, 1024, 2048, 3072]  # D
+    return configs
+
+
+def get_model_config(model_name: str) -> ml_collections.ConfigDict:
+    """
+    Get the model configuration for the given model name.
+
+    Args:
+        model_name (str): Name of the model.
+
+    Returns:
+        ml_collections.ConfigDict: Model configuration.
+    """
+    if model_name == "coatnet_0":
+        return coatnet_0_config()
+    elif model_name == "coatnet_1":
+        return coatnet_1_config()
+    elif model_name == "coatnet_2":
+        return coatnet_2_config()
+    elif model_name == "coatnet_3":
+        return coatnet_3_config()
+    elif model_name == "coatnet_4":
+        return coatnet_4_config()
+    elif model_name == "coatnet_5":
+        return coatnet_5_config()
+    elif model_name == "coatnet_6":
+        return coatnet_6_config()
+    else:
+        return coatnet_7_config()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib==3.5.2
 ml-collections==0.1.0
 pytest==6.2.5
 tensorflow==2.9.0
+tensorflow-addons==0.17.0

--- a/scripts/train_model.sh
+++ b/scripts/train_model.sh
@@ -1,0 +1,1 @@
+python3 train.py --experiment_configs configs/classifier.py

--- a/train.py
+++ b/train.py
@@ -1,0 +1,30 @@
+import os
+from datetime import datetime
+
+from absl import app, flags, logging
+from ml_collections.config_flags import config_flags
+
+from coatnet.models.coatnet import CoAtNet
+
+FLAGS = flags.FLAGS
+config_flags.DEFINE_config_file("experiment_configs")
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+
+
+def main(_):
+
+    model = CoAtNet(
+        model_name=FLAGS.experiment_configs.model_name,
+        image_shape=(
+            FLAGS.experiment_configs.image_height,
+            FLAGS.experiment_configs.image_width,
+            FLAGS.experiment_configs.image_channels,
+        ),
+        num_classes=FLAGS.experiment_configs.num_classes,
+    )
+
+    model.get_training_model()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/train.py
+++ b/train.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from absl import app, flags, logging
 from ml_collections.config_flags import config_flags
 
-from coatnet.models.coatnet import CoAtNet
+from coatnet.models.coatnet import get_training_model
 
 FLAGS = flags.FLAGS
 config_flags.DEFINE_config_file("experiment_configs")
@@ -13,7 +13,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
 def main(_):
 
-    model = CoAtNet(
+    model = get_training_model(
         model_name=FLAGS.experiment_configs.model_name,
         image_shape=(
             FLAGS.experiment_configs.image_height,
@@ -22,8 +22,6 @@ def main(_):
         ),
         num_classes=FLAGS.experiment_configs.num_classes,
     )
-
-    model.get_training_model()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added the Conv Stem Stage and also wrote the configs for all the variants of models. 

The Output shape of the Conv stem stage is (112, 112, 64) which is same as the shape reported in the [paper](https://arxiv.org/pdf/2106.04803.pdf).

```
print(conv_2.shape)
```
This is written for verification purpose.

- [X] Stem Block
- [ ] MBConv Block
- [ ] Relative Attention Block
- [ ] FFN Block
- [ ] Output Block
